### PR TITLE
Create Lua port of Python Script for MacOS

### DIFF
--- a/scripts/obs_tally_light.lua
+++ b/scripts/obs_tally_light.lua
@@ -40,7 +40,6 @@ function script_update(settings)
 end
 
 function load_input_settings(settings)
-	obs.script_log(obs.LOG_INFO, "Loading INput Settings")
 	local sources = obs.obs_enum_sources()
 	if sources ~= nil then
 		for _, source in ipairs(sources) do
@@ -109,7 +108,10 @@ function call_tally_light(source, color, brightness)
 	local pctBright = brightness / 10
 	local url = "http://" .. addr .. ":7413/set?color=" .. hexColor .. "&brightness=" .. pctBright
 
-	obs.script_log(obs.LOG_INFO, "CALLING " .. url)
+	local status = os.execute("curl --connect-timeout 2 --max-time 4 '" .. url .. "'" )
+	if status > 0 then
+		obs.script_log(obs.LOG_ERROR, "Error connecting to: " .. url)
+	end
 end
 
 function get_item_names_by_scene(source)

--- a/scripts/obs_tally_light.lua
+++ b/scripts/obs_tally_light.lua
@@ -104,9 +104,12 @@ function call_tally_light(source, color, brightness)
 		do return end
 	end
 
-	local hexColor = string.sub(string.format("%x", color), 3)
+	local hexColor = string.format("%x", color)
+	local hexBlue = string.sub(hexColor, 3, 4)
+	local hexGreen = string.sub(hexColor, 5, 6)
+	local hexRed = string.sub(hexColor, 7, 8)
 	local pctBright = brightness / 10
-	local url = "http://" .. addr .. ":7413/set?color=" .. hexColor .. "&brightness=" .. pctBright
+	local url = "http://" .. addr .. ":7413/set?color=" .. hexRed .. hexGreen .. hexBlue .. "&brightness=" .. pctBright
 
 	local status = os.execute("curl --connect-timeout 2 --max-time 4 '" .. url .. "'" )
 	if status > 0 then

--- a/scripts/obs_tally_light.lua
+++ b/scripts/obs_tally_light.lua
@@ -1,5 +1,4 @@
 obs = obslua
-settings = {}
 light_mapping = {}
 idle_color = tonumber('FF0000FF', 16)
 idle_brightness = 5
@@ -95,7 +94,7 @@ function call_tally_light(source, color, brightness)
 		do return end
 	end
 
-	local hexColor = string.format("%x", color)
+	local hexColor = string.sub(string.format("%x", color), 3)
 	local pctBright = brightness / 10
 	local url = "http://" .. addr .. ":7413/set?color=" .. hexColor .. "&brightness=" .. pctBright
 
@@ -112,13 +111,11 @@ function get_item_names_by_scene(source)
 		local item_source = obs.obs_sceneitem_get_source(item)
 		local item_name = obs.obs_source_get_name(item_source)
 		if light_mapping[item_name] ~= nil then
-			obs.script_log(obs.LOG_INFO, "Scene Item: " .. item_name)
-			table.insert(item_names, item_name)
+			item_names[item_name] = item_name
 		end
 	end
 
 	obs.sceneitem_list_release(scene_items)
-
 	return item_names
 end
 
@@ -131,7 +128,7 @@ end
 
 function set_idle_lights()
 	for src, addr in pairs(light_mapping) do
-		if program_items[src] == null and preview_items[src] == null then
+		if (program_items[src] == null) and (preview_items[src] == null) then
 			call_tally_light(src, idle_color, idle_brightness)
 		end
 	end
@@ -145,7 +142,7 @@ function handle_preview_change()
 	local preview_source = obs.obs_frontend_get_current_preview_scene()
 	local preview_name = obs.obs_source_get_name(preview_source)
 
-	local preview_items = get_item_names_by_scene(preview_source)
+	preview_items = get_item_names_by_scene(preview_source)
 	if program_name ~= preview_name then
 		set_lights_by_items(preview_items, preview_color, preview_brightness)
 	end
@@ -156,7 +153,7 @@ end
 
 function handle_program_change()
 	local program_source = obs.obs_frontend_get_current_scene()
-	local program_items = get_item_names_by_scene(program_source)
+	program_items = get_item_names_by_scene(program_source)
 	set_lights_by_items(program_items, program_color, program_brightness)
 	obs.obs_source_release(program_source)
 	set_idle_lights()

--- a/scripts/obs_tally_light.lua
+++ b/scripts/obs_tally_light.lua
@@ -1,0 +1,169 @@
+obs = obslua
+settings = {}
+light_mapping = {}
+idle_color = tonumber('FF0000FF', 16)
+idle_brightness = 5
+preview_color = tonumber('FF00FF00', 16)
+preview_brightness = 5
+preview_items = {}
+program_color = tonumber('FFFF0000', 16)
+program_brightness = 5
+program_items = {}
+http_timeout_seconds = 4
+
+function script_description()
+	return [[
+Remote tally lights for camera input sources.
+]]
+end
+
+function script_defaults(settings)
+	obs.obs_data_set_default_int(settings, "tally^IdleColor", tonumber('ffff0000', 16))
+	obs.obs_data_set_default_int(settings, "tally^IdleBrightness", 5)
+	obs.obs_data_set_default_int(settings, "tally^PreviewColor", tonumber('ff00ff00', 16))
+	obs.obs_data_set_default_int(settings, "tally^PreviewBrightness", 5)
+	obs.obs_data_set_default_int(settings, "tally^ProgramColor", tonumber('ff0000ff', 16))
+	obs.obs_data_set_default_int(settings, "tally^ProgramBrightness", 5)
+end
+
+function script_update(settings)
+	local settings_map = settings_dict(settings)
+	for k, v in ipairs(settings_map) do
+		if strsub(k, 0, 6) ~= "tally^" then
+			light_mapping[k] = v
+		end
+	end
+
+	idle_color = obs.obs_data_get_int(settings, "tally^IdleColor")
+	idle_brightness = obs.obs_data_get_int(settings, "tally^IdleBrightness")
+	preview_color = obs.obs_data_get_int(settings, "tally^PreviewColor")
+	preview_brightness = obs.obs_data_get_int(settings, "tally^PreviewBrightness")
+	program_color = obs.obs_data_get_int(settings, "tally^ProgramColor")
+	program_brightness = obs.obs_data_get_int(settings, "tally^ProgramBrightness")
+end
+
+function script_properties()
+	local props = obs.obs_properties_create()
+
+	obs.obs_properties_add_color(props, "tally^IdleColor", "Idle Color")
+	obs.obs_properties_add_int_slider(props, "tally^IdleBrightness", "Idle Brightness", 0, 10, 1)
+	obs.obs_properties_add_color(props, "tally^PreviewColor", "Queued Color")
+	obs.obs_properties_add_int_slider(props, "tally^PreviewBrightness", "Queued Brightness", 0, 10, 1)
+	obs.obs_properties_add_color(props, "tally^ProgramColor", "Live Color")
+	obs.obs_properties_add_int_slider(props, "tally^ProgramBrightness", "Live Brightness", 0, 10, 1)
+
+	local sources = obs.obs_enum_sources()
+	if sources ~= nil then
+		for _, source in ipairs(sources) do
+			source_id = obs.obs_source_get_id(source)
+			if source_id == "av_capture_input" then
+				local source_name = obs.obs_source_get_name(source)
+				obs.script_log(obs.LOG_INFO, "Found source: " .. source_name)
+				obs.obs_properties_add_text(props, source_name, source_name .. " light addr:", obs.OBS_TEXT_DEFAULT)
+			end
+		end
+	end
+	obs.source_list_release(sources)
+
+	return props
+end
+
+function script_update(_settings)
+	settings = _settings
+end
+
+function script_load(settings)
+	obs.obs_frontend_add_event_callback(handle_event)
+end
+
+function handle_event(event)
+	if event == obs.OBS_FRONTEND_EVENT_SCENE_CHANGED then
+		handle_program_change()
+	elseif event == obs.OBS_FRONTEND_EVENT_PREVIEW_SCENE_CHANGED then
+		handle_preview_change()
+	elseif event == obs.OBS_FRONTEND_EVENT_EXIT then
+		handle_exit()
+	end
+end
+
+function call_tally_light(source, color, brightness)
+	local addr = light_mapping[source]
+	if addr == nil then
+		obs.script_log(obs.LOG_INFO, "No tally light set for: %s" .. source)
+		do return end
+	end
+
+	local hexColor = substr(hex(color), 10, 3)
+	local pctBright = brightness / 10
+	local url = "http://" .. addr .. ":7413/set?color=" .. hexColor .. "&brightness=" .. pctBright
+
+	obs.script_log(obs.LOG_INFO, "CALLING " .. url)
+end
+
+function get_item_names_by_scene(source)
+	local item_names = {}
+	local scene = obs.obs_scene_from_source(source)
+	local scene_name = obs.obs_source_get_name(source)
+	local scene_items = obs.obs_scene_enum_items(scene)
+
+	if scene_items ~= nil then
+		for item in scene_items do
+			local item_source = obs.obs_sceneitem_get_source(item)
+			local item_name = obs.obs_source_get_name(item_source)
+			if light_mapping[item_name] ~= nil then
+				table.insert(item_names, item_name)
+			end
+		end
+		obs.sceneitem_list_release(scene_items)
+	end
+
+	return item_names
+end
+
+function set_lights_by_items(item_names, color, brightness)
+	for item_name in item_names do
+		obs.script_log(obs.LOG_INFO, "Calling Light for [%s]" .. item_name)
+		call_tally_light(item_name, color, brightness)
+	end
+end
+
+function set_idle_lights()
+	local excluded_items = program_items + preview_items
+
+	for src, addr in ipairs(light_mapping) do
+		if excluded_items[src] == null then
+			call_tally_light(src, idle_color, idle_brightness)
+		end
+	end
+end
+
+function handle_preview_change()
+	local program_source = obs.obs_frontend_get_current_scene()
+	local program_name = obs.obs_source_get_name(program_source)
+	obs.obs_source_release(program_source);
+
+	local preview_source = obs.obs_frontend_get_current_preview_scene()
+	local preview_name = obs.obs_source_get_name(preview_source)
+
+	local preview_items = get_item_names_by_scene(preview_source)
+	if program_name ~= preview_name then
+		set_lights_by_items(preview_items, preview_color, preview_brightness)
+	end
+
+	obs.obs_source_release(preview_source);
+	set_idle_lights()
+end
+
+function handle_program_change()
+	local program_source = obs.obs_frontend_get_current_scene()
+	local program_items = get_item_names_by_scene(program_source)
+	set_lights_by_items(program_items, program_color, program_brightness)
+	obs.obs_source_release(program_source)
+	set_idle_lights()
+end
+
+function handle_exit()
+	for src, addr in ipairs(light_mapping.items) do
+		call_tally_light(src, "00000000", 0);
+	end
+end

--- a/scripts/obs_tally_light.lua
+++ b/scripts/obs_tally_light.lua
@@ -90,7 +90,7 @@ function handle_event(event)
 	elseif event == obs.OBS_FRONTEND_FINISHED_LOADING then
 		handle_loaded()
 	elseif event == obs.OBS_FRONTEND_EVENT_SCENE_CHANGED then
-		if(table.getn(light_mapping) <= 0) then load_input_settings(settings_cache) end
+		if next(light_mapping) == nil then load_input_settings(settings_cache) end
 		handle_program_change()
 	elseif event == obs.OBS_FRONTEND_EVENT_PREVIEW_SCENE_CHANGED then
 		handle_preview_change()
@@ -99,8 +99,8 @@ end
 
 function call_tally_light(source, color, brightness)
 	local addr = light_mapping[source]
-	if addr == nil then
-		obs.script_log(obs.LOG_INFO, "No tally light set for: %s" .. source)
+	if (addr == nil) or (string.len(addr) <= 0) then
+		obs.script_log(obs.LOG_INFO, "No tally light set for: " .. source)
 		do return end
 	end
 
@@ -134,14 +134,13 @@ end
 
 function set_lights_by_items(item_names, color, brightness)
 	for _, item_name in pairs(item_names) do
-		obs.script_log(obs.LOG_INFO, "Calling Light for: " .. item_name)
 		call_tally_light(item_name, color, brightness)
 	end
 end
 
 function set_idle_lights()
 	for src, addr in pairs(light_mapping) do
-		if (program_items[src] == null) and (preview_items[src] == null) then
+		if (program_items[src] == nil) and (preview_items[src] == nil) then
 			call_tally_light(src, idle_color, idle_brightness)
 		end
 	end

--- a/scripts/obs_tally_light.lua
+++ b/scripts/obs_tally_light.lua
@@ -107,8 +107,8 @@ function get_item_names_by_scene(source)
 	local scene_items = obs.obs_scene_enum_items(scene)
 
 	if scene_items ~= nil then
-		for item in scene_items do
-			local item_source = obs.obs_sceneitem_get_source(item)
+		for _, scene_item in ipairs(scene_items) do
+			local item_source = obs.obs_sceneitem_get_source(scene_item)
 			local item_name = obs.obs_source_get_name(item_source)
 			if light_mapping[item_name] ~= nil then
 				table.insert(item_names, item_name)
@@ -121,14 +121,14 @@ function get_item_names_by_scene(source)
 end
 
 function set_lights_by_items(item_names, color, brightness)
-	for item_name in item_names do
+	for _, item_name in ipairs(item_names) do
 		obs.script_log(obs.LOG_INFO, "Calling Light for [%s]" .. item_name)
 		call_tally_light(item_name, color, brightness)
 	end
 end
 
 function set_idle_lights()
-	local excluded_items = program_items + preview_items
+	local excluded_items = table.insert(program_items, preview_items)
 
 	for src, addr in ipairs(light_mapping) do
 		if excluded_items[src] == null then

--- a/scripts/obs_tally_light.py
+++ b/scripts/obs_tally_light.py
@@ -137,7 +137,7 @@ def handle_preview_change():
 
 	program_source = obs.obs_frontend_get_current_scene()
 	program_name = obs.obs_source_get_name(program_source)
-	obs.obs_source_release(program_source);
+	obs.obs_source_release(program_source)
 
 	preview_source = obs.obs_frontend_get_current_preview_scene()
 	preview_name = obs.obs_source_get_name(preview_source)
@@ -160,4 +160,4 @@ def handle_program_change():
 
 def handle_exit():
 	for src, addr in light_mapping.items():
-		call_tally_light(src, "00000000", 0);
+		call_tally_light(src, "00000000", 0)

--- a/scripts/obs_tally_light.py
+++ b/scripts/obs_tally_light.py
@@ -123,14 +123,14 @@ def get_item_names_by_scene(source):
 def set_lights_by_items(item_names, color, brightness):
 	for item_name in item_names:
 		obs.script_log(obs.LOG_INFO, 'Calling Light for [%s]' % (item_name))
-		call_tally_light(item_name, color, brightness);
+		call_tally_light(item_name, color, brightness)
 
 def set_idle_lights():
 	excluded_items = program_items + preview_items
 
 	for src, addr in light_mapping.items():
 		if src not in excluded_items:
-			call_tally_light(src, idle_color, idle_brightness);
+			call_tally_light(src, idle_color, idle_brightness)
 
 def handle_preview_change():
 	global preview_items
@@ -146,7 +146,7 @@ def handle_preview_change():
 	if program_name != preview_name:
 		set_lights_by_items(preview_items, preview_color, preview_brightness)
 
-	obs.obs_source_release(preview_source);
+	obs.obs_source_release(preview_source)
 	set_idle_lights()
 
 def handle_program_change():
@@ -155,7 +155,7 @@ def handle_program_change():
 	program_source = obs.obs_frontend_get_current_scene()
 	program_items = get_item_names_by_scene(program_source)
 	set_lights_by_items(program_items, program_color, program_brightness)
-	obs.obs_source_release(program_source);
+	obs.obs_source_release(program_source)
 	set_idle_lights()
 
 def handle_exit():

--- a/scripts/obs_tally_light.py
+++ b/scripts/obs_tally_light.py
@@ -14,12 +14,12 @@ program_brightness = 5
 program_items = []
 http_timeout_seconds = 4
 
+def script_description():
+	return "Remote tally lights for camera input sources."
+
 def settings_dict(settings):
 	settings_json = obs.obs_data_get_json(settings)
 	return json.loads(settings_json)
-
-def script_description():
-	return "Remote tally lights for camera input sources."
 
 def script_defaults(settings):
 	obs.obs_data_set_default_int(settings, "tally^IdleColor", int('ffff0000', 16))

--- a/scripts/obs_tally_light.py
+++ b/scripts/obs_tally_light.py
@@ -91,9 +91,12 @@ def call_tally_light(source, color, brightness):
 		obs.script_log(obs.LOG_INFO, 'No tally light set for: %s' % (source))
 		return
 
-	hexColor = hex(color)[10:3:-1]
+	hexColor = hex(color)
+	hexBlue = hexColor[2:4]
+	hexGreen = hexColor[4:6]
+	hexRed = hexColor[6:8]
 	pctBright = brightness / 10
-	url = 'http://%s:7413/set?color=%s&brightness=%f' % (addr, hexColor, pctBright)
+	url = 'http://%s:7413/set?color=%s%s%s&brightness=%f' % (addr, hexRed, hexGreen, hexBlue, pctBright)
 
 	try:
 		with urllib.request.urlopen(url, None, http_timeout_seconds) as response:


### PR DESCRIPTION
Attempt to address Issue #12 by porting the Python script to Lua. This will require a system call to `curl` unfortunately, since the Lua HTTP libraries are not packaged with OBS.